### PR TITLE
Skip create-project scripts so --no-install doesn't fail on key:generate

### DIFF
--- a/.github/workflows/generate-commands.yml
+++ b/.github/workflows/generate-commands.yml
@@ -56,7 +56,7 @@ jobs:
             - name: Install Laravel
               # Disable Composer advisory block so EOL installs work.
               run: |
-                composer create-project --no-progress --no-install laravel/laravel="^${{ matrix.laravel.v }}" /tmp/laravel
+                composer create-project --no-progress --no-install --no-scripts laravel/laravel="^${{ matrix.laravel.v }}" /tmp/laravel
                 cd /tmp/laravel
                 composer config policy.advisories.block false
                 composer install --no-progress


### PR DESCRIPTION
Follow-up to #46. --no-install still runs key:generate, which fatals with no vendor and kills the step under bash -e. --no-scripts skips it. Verified locally: installs v11.54.0, regenerates 11.x.json identically (127 commands).