### PR TITLE
Handle OPTIONS preflight on API routes

### DIFF
--- a/pages/api/commands.ts
+++ b/pages/api/commands.ts
@@ -11,6 +11,9 @@ export default async function handler(req: NextRequest, res: NextResponse) {
     const search = req.nextUrl.searchParams.get('s')
     const v = req.nextUrl.searchParams.get('v')
 
+    if (req.method === 'OPTIONS') {
+        return cors(req, new NextResponse(null))
+    }
     if (req.method !== 'GET') {
         return new Response(JSON.stringify({}), {
             status: 405,

--- a/pages/api/versions.ts
+++ b/pages/api/versions.ts
@@ -7,6 +7,9 @@ export const config = {
 }
 
 export default async function handler(req: NextRequest, res: NextResponse) {
+    if (req.method === 'OPTIONS') {
+        return cors(req, new NextResponse(null))
+    }
     if (req.method !== 'GET') {
         return new Response(JSON.stringify({}), {
             status: 405,


### PR DESCRIPTION
The method guard returned 405 for `OPTIONS` before `cors()` ran, so CORS preflights were rejected (and the cors lib's OPTIONS branch was dead code). Now routes `OPTIONS` through `cors()` → 204 with the `Access-Control-*` headers. Plain GETs are unaffected (simple requests, no preflight). Verified locally: OPTIONS → 204 with allow-methods/headers, GET → 200, POST → 405.